### PR TITLE
Add popup image upload

### DIFF
--- a/application/controllers/Popup.php
+++ b/application/controllers/Popup.php
@@ -90,6 +90,7 @@ class Popup extends CI_Controller {
     $pop_type      = empty($_POST['pop_type'])     ? '' : $_POST['pop_type'];
     $pop_title     = empty($_POST['pop_title'])    ? '' : $_POST['pop_title'];
     $pop_contents  = empty($_POST['pop_contents']) ? '' : $_POST['pop_contents'];
+    $pop_img       = empty($_POST['pop_img'])      ? '' : $_POST['pop_img'];
     $pop_start     = empty($_POST['pop_start'])    ? '' : $_POST['pop_start'];
     $pop_end       = empty($_POST['pop_end'])      ? '' : $_POST['pop_end'];
     $is_view       = empty($_POST['is_view'])      ? 'N' : $_POST['is_view'];
@@ -106,6 +107,7 @@ class Popup extends CI_Controller {
     $tpl_vars['POP_END']      = '';
     $tpl_vars['IS_VIEW']      = 'N';
     $tpl_vars['POP_ORDER']    = 0;
+    $tpl_vars['POP_IMG']      = '';
 
     if(!empty($_POST)){
 
@@ -117,9 +119,13 @@ class Popup extends CI_Controller {
       if(empty($tpl_vars['ERROR'])) {
         $result = $this->popup_model->set_popup(
           $pop_id, $pop_type, $pop_title, $pop_contents,
-          '', '0', '0', $pop_start, $pop_end, $pop_order, $is_view, L_USR_ID
+          $pop_img, '0', '0', $pop_start, $pop_end, $pop_order, $is_view, L_USR_ID
         );
         if($result){
+          if(!empty($pop_img)){
+            @copy(DATA_FILEPATH."/temp/".$pop_img, DATA_FILEPATH."/popup/".$pop_img);
+            @unlink(DATA_FILEPATH."/temp/".$pop_img);
+          }
           $tpl_vars['REDIRECT_URL'] = base_url()."index.php/manager/popup/index";
           $tpl_vars['ERROR_MESSAGE'] = "저장되었습니다.";
           $this->parser->parse('errors/redirect', $tpl_vars);

--- a/application/views/popup/write.php
+++ b/application/views/popup/write.php
@@ -21,6 +21,7 @@
 
                     <form action="{CURRENT_URL}" method="post" class="form-horizontal form-label-left" novalidate>
                       <input type="hidden" name="pop_id" value="{POP_ID}" />
+                      <input type="hidden" name="pop_img" value="{POP_IMG}" />
                       <div class="item form-group">
                         <div class="col-md-12 col-sm-12 col-xs-12">
                           <label for="pop_title">타이틀</label>
@@ -63,6 +64,40 @@
                         </div>
                       </div>
                     </form>
+
+                    <div class="clearfix"></div>
+
+                    <div class="row">
+                      <div class="col-md-12 col-sm-12 col-xs-12">
+                        <div class="x_panel">
+                          <div class="x_title">
+                            <h2>이미지 첨부하기</h2>
+                          </div>
+                          <div class="x_content">
+                            <form action="{BASE_URL}index.php/request/image_upload" class="dropzone" drop-zone="" id="pop-file-dropzone">
+                              <div class="dz-message text-center alert alert-secondary">
+                                <h2><strong>이미지를 이곳에 드롭다운 하시거나 여기를 클릭해 주세요.</strong></h2>
+                                <p>첨부가능한 이미지는 jpg, jpeg, png입니다.</p>
+                              </div>
+                            </form>
+                            <div style="display:none;" class="pop-upload-progress text-center alert alert-info">
+                              <h2><i class="fa fa-refresh fa-spin"></i><strong> 파일을 업로드중 입니다.</strong></h2>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+
+                    <div id="pop-banner-preview" class="dropzone-previews hide"></div>
+                    <div class="col-lg-12 col-md-12 col-sm-12 text-center ">
+                      <div class="pop-image-preview">
+                        <img src="" id="pop-preview-img">
+                        <br />
+                        <br />
+                        <br />
+                      </div>
+                    </div>
+
                     <div class="ln_solid"></div>
 
                     <div class="form-group">
@@ -120,6 +155,41 @@
 
       $('.multi.required').on('keyup blur', 'input', function() {
         validator.checkField.apply($(this).siblings().last()[0]);
+      });
+
+      $('#pop-file-dropzone').dropzone({
+        url: "{BASE_URL}index.php/request/image_upload",
+        maxFilesize: 300,
+        paramName: "image",
+        maxThumbnailFilesize: 1,
+        previewsContainer: ".dropzone-previews",
+        init: function() {
+          this.on('success', function(file, json) {
+            var res = JSON.parse(json);
+            if(res.ERROR == 'OK'){
+              $(".pop-upload-progress").hide();
+              $(".pop-image-preview").show();
+
+              var img_name = res.FILENAME;
+              $("input[name='pop_img']").val(res.FILENAME);
+              $("#pop-preview-img").attr("src", "{BASE_URL}index.php/request/image_view/"+img_name+"/temp");
+            } else {
+              $("#pop-file-dropzone").show();
+              $(".pop-upload-progress").hide();
+              alert(res.ERROR_MESSAGE);
+            }
+          });
+
+          this.on('addedfile', function(file) {
+            $("#pop-file-dropzone").hide();
+            $(".pop-upload-progress").show();
+          });
+
+          this.on('drop', function(file) {
+            $("#pop-file-dropzone").hide();
+            $(".pop-upload-progress").show();
+          });
+        }
       });
     </script>
     <!-- /validator -->


### PR DESCRIPTION
## Summary
- 팝업 작성 페이지에 이미지 업로드 기능 추가
- 업로드된 파일명은 숨겨진 `pop_img` 필드에 저장하고 미리보기 표시
- 팝업 저장 시 업로드한 이미지를 임시 폴더에서 popup 폴더로 이동

## Testing
- `php -l application/views/popup/write.php`
- `php -l application/controllers/Popup.php`


------
https://chatgpt.com/codex/tasks/task_e_686e16ef5e688322926486f0ec7430a8